### PR TITLE
Fix: Update image paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ A comprehensive members-only golf application for tracking scorecards, handicaps
 
 ## Screenshots
 
-![Dashboard](docs/dashboard-screenshot.png)
-![Scorecard](docs/scorecard-screenshot.png)
-![Leaderboard](docs/leaderboard-screenshot.png)
+![Dashboard](docs/screenshots/dashboard-screenshot.png)
+![Scorecard](docs/screenshots/scorecard-screenshot.png)
+![Leaderboard](docs/screenshots/leaderboard-screenshot.png)
 
 ## Quick Start
 


### PR DESCRIPTION
The image paths in README.md were pointing to the wrong directory. This commit updates the paths to correctly point to the images in the `docs/screenshots/` directory.